### PR TITLE
ENTMQBR-2070 Add support for AIO in the broker image

### DIFF
--- a/pkg/resources/statefulsets/statefulset.go
+++ b/pkg/resources/statefulsets/statefulset.go
@@ -239,6 +239,8 @@ func getPropertyForCR(propName string, cr *brokerv1alpha1.ActiveMQArtemis, defau
 	case "AMQ_EXTRA_ARGS":
 		if cr.Spec.Aio {
 			result = "--aio"
+		} else {
+			result = "--nio"
 		}
 	}
 	return result


### PR DESCRIPTION
Commit #2: Add --nio arg if the aio parameter is false.
The reason to add this is that when --aio arg is omitted,
the broker always try to use AIO journal if possible.
This change allows user to choose NIO even if the AIO is
available.