### PR TITLE
Fix autogenerated method to avoid calls to non-existent packages

### DIFF
--- a/pkg/apis/addtoscheme_broker_v2alpha1.go
+++ b/pkg/apis/addtoscheme_broker_v2alpha1.go
@@ -1,11 +1,10 @@
 package apis
 
 import (
-	routev1 "github.com/openshift/api/route/v1"
 	"github.com/rh-messaging/activemq-artemis-operator/pkg/apis/broker/v2alpha1"
 )
 
 func init() {
 	// Register the types with the Scheme so the components can map objects to GroupVersionKinds and back
-	AddToSchemes = append(AddToSchemes, v2alpha1.SchemeBuilder.AddToScheme, routev1.SchemeBuilder.AddToScheme)
+	AddToSchemes = append(AddToSchemes, v2alpha1.SchemeBuilder.AddToScheme, v2alpha1.SchemeBuilder.AddToScheme)
 }


### PR DESCRIPTION
This call breaks compilation. Was fixed locally, didn't get into previous PR. 