### PR TITLE
ENTMQBR-3597 Statefulset recreated on startup

### DIFF
--- a/pkg/controller/broker/v2alpha2/activemqartemis/activemqartemis_reconciler.go
+++ b/pkg/controller/broker/v2alpha2/activemqartemis/activemqartemis_reconciler.go
@@ -81,24 +81,30 @@ func (reconciler *ActiveMQArtemisReconciler) Process(customResource *brokerv2alp
 	// TODO: Remove singular admin level user and password in favour of at least guest and admin access
 	secretName := secrets.CredentialsNameBuilder.Name()
 
-	envVarName := "AMQ_USER"
+	envVarName1 := "AMQ_USER"
 	adminUser := customResource.Spec.AdminUser
 	if "" == adminUser {
 		adminUser = environments.Defaults.AMQ_USER
 	}
-	statefulSetUpdates := sourceEnvVarFromSecret(customResource, currentStatefulSet, adminUser, envVarName, secretName, client, scheme)
 
-	envVarName = "AMQ_PASSWORD"
+	envVarName2 := "AMQ_PASSWORD"
 	adminPassword := customResource.Spec.AdminPassword
 	if "" == adminPassword {
 		adminPassword = environments.Defaults.AMQ_PASSWORD
 	}
-	statefulSetUpdates |= sourceEnvVarFromSecret(customResource, currentStatefulSet, adminPassword, envVarName, secretName, client, scheme)
+
+	envVars := make(map[string]string)
+	envVars[envVarName1] = adminUser
+	envVars[envVarName2] = adminPassword
+
+	statefulSetUpdates := sourceEnvVarFromSecret(customResource, currentStatefulSet, &envVars, secretName, client, scheme)
 
 	statefulSetUpdates |= reconciler.ProcessDeploymentPlan(customResource, client, scheme, currentStatefulSet, firstTime)
-	statefulSetUpdates |= reconciler.ProcessAcceptors(customResource, client, scheme, currentStatefulSet)
-	statefulSetUpdates |= reconciler.ProcessConnectors(customResource, client, scheme, currentStatefulSet)
+
+	statefulSetUpdates |= reconciler.ProcessAcceptorsAndConnectors(customResource, client, scheme, currentStatefulSet)
+
 	statefulSetUpdates |= reconciler.ProcessConsole(customResource, client, scheme, currentStatefulSet)
+
 	requestedResources = append(requestedResources, allObjects...)
 	stepsComplete := reconciler.processUpgrade(customResource, client, scheme, currentStatefulSet)
 
@@ -139,28 +145,24 @@ func (reconciler *ActiveMQArtemisReconciler) ProcessDeploymentPlan(customResourc
 	return reconciler.statefulSetUpdates
 }
 
-func (reconciler *ActiveMQArtemisReconciler) ProcessAcceptors(customResource *brokerv2alpha2.ActiveMQArtemis, client client.Client, scheme *runtime.Scheme, currentStatefulSet *appsv1.StatefulSet) uint32 {
+func (reconciler *ActiveMQArtemisReconciler) ProcessAcceptorsAndConnectors(customResource *brokerv2alpha2.ActiveMQArtemis, client client.Client, scheme *runtime.Scheme, currentStatefulSet *appsv1.StatefulSet) uint32 {
 
 	var retVal uint32 = statefulSetNotUpdated
 
 	acceptorEntry := generateAcceptorsString(customResource, client)
-	configureAcceptorsExposure(customResource, client, scheme)
-	envVarName := "AMQ_ACCEPTORS"
-	secretName := secrets.NettyNameBuilder.Name()
-	retVal = sourceEnvVarFromSecret(customResource, currentStatefulSet, acceptorEntry, envVarName, secretName, client, scheme)
-
-	return retVal
-}
-
-func (reconciler *ActiveMQArtemisReconciler) ProcessConnectors(customResource *brokerv2alpha2.ActiveMQArtemis, client client.Client, scheme *runtime.Scheme, currentStatefulSet *appsv1.StatefulSet) uint32 {
-
-	var retVal uint32 = statefulSetNotUpdated
-
 	connectorEntry := generateConnectorsString(customResource, client)
+
+	configureAcceptorsExposure(customResource, client, scheme)
 	configureConnectorsExposure(customResource, client, scheme)
-	envVarName := "AMQ_CONNECTORS"
+
+	envVars := map[string]string {
+		"AMQ_ACCEPTORS" : acceptorEntry,
+		"AMQ_CONNECTORS" : connectorEntry,
+	}
+
 	secretName := secrets.NettyNameBuilder.Name()
-	retVal = sourceEnvVarFromSecret(customResource, currentStatefulSet, connectorEntry, envVarName, secretName, client, scheme)
+
+	retVal = sourceEnvVarFromSecret(customResource, currentStatefulSet, &envVars, secretName, client, scheme)
 
 	return retVal
 }
@@ -181,7 +183,11 @@ func (reconciler *ActiveMQArtemisReconciler) ProcessConsole(customResource *brok
 		secretName = customResource.Spec.Console.SSLSecret
 	}
 	sslFlags = generateConsoleSSLFlags(customResource, client, secretName)
-	retVal = sourceEnvVarFromSecret(customResource, currentStatefulSet, sslFlags, envVarName, secretName, client, scheme)
+
+	envVars := make(map[string]string)
+	envVars[envVarName] = sslFlags
+
+	retVal = sourceEnvVarFromSecret(customResource, currentStatefulSet, &envVars, secretName, client, scheme)
 
 	return retVal
 }
@@ -232,7 +238,7 @@ func syncMessageMigration(customResource *brokerv2alpha2.ActiveMQArtemis, client
 	}
 }
 
-func sourceEnvVarFromSecret(customResource *brokerv2alpha2.ActiveMQArtemis, currentStatefulSet *appsv1.StatefulSet, acceptorEntry string, envVarName string, secretName string, client client.Client, scheme *runtime.Scheme) uint32 {
+func sourceEnvVarFromSecret(customResource *brokerv2alpha2.ActiveMQArtemis, currentStatefulSet *appsv1.StatefulSet, envVars *map[string]string, secretName string, client client.Client, scheme *runtime.Scheme) uint32 {
 
 	var err error = nil
 	var retVal uint32 = statefulSetNotUpdated
@@ -242,47 +248,65 @@ func sourceEnvVarFromSecret(customResource *brokerv2alpha2.ActiveMQArtemis, curr
 		Namespace: currentStatefulSet.Namespace,
 	}
 	// Attempt to retrieve the secret
-	stringDataMap := map[string]string{
-		envVarName: acceptorEntry,
+	stringDataMap := make(map[string]string)
+
+	for k := range *envVars {
+		stringDataMap[k] = (*envVars)[k]
 	}
+
 	nettySecret := secrets.NewSecret(namespacedName, secretName, stringDataMap)
 	if err = resources.Retrieve(namespacedName, client, nettySecret); err != nil {
 		if errors.IsNotFound(err) {
 			requestedResources = append(requestedResources, nettySecret)
-			//err = resources.Create(customResource, client, scheme, nettySecret)
 		}
 	} else { // err == nil so it already exists
 		// Exists now
 		// Check the contents against what we just got above
-		elem, ok := nettySecret.Data[envVarName]
-		if 0 != strings.Compare(string(elem), acceptorEntry) || !ok {
-			nettySecret.Data[envVarName] = []byte(acceptorEntry)
 
+		var needUpdate bool = false
+		for k := range *envVars {
+			elem, ok := nettySecret.Data[k]
+			if 0 != strings.Compare(string(elem), (*envVars)[k]) || !ok {
+				log.Info("Secret exists but not equals, or not ok", "elem", string(elem), "entry", (*envVars)[k], "ok?", ok)
+				nettySecret.Data[k] = []byte((*envVars)[k])
+				needUpdate = true
+			}
+		}
+
+		if needUpdate {
 			// These updates alone do not trigger a rolling update due to env var update as it's from a secret
 			err = resources.Update(namespacedName, client, nettySecret)
 
 			// Force the rolling update to occur
 			environments.IncrementTriggeredRollCount(currentStatefulSet.Spec.Template.Spec.Containers)
+
+			//so far it doesn't matter what the value is as long as it's greater than zero
 			retVal = statefulSetAcceptorsUpdated
 		}
 	}
 
-	acceptorsEnvVarSource := &corev1.EnvVarSource{
-		SecretKeyRef: &corev1.SecretKeySelector{
-			LocalObjectReference: corev1.LocalObjectReference{
-				Name: secretName,
+	log.Info("Pupulating env vars", "envVars", *envVars)
+
+	for envVarName := range *envVars {
+
+		acceptorsEnvVarSource := &corev1.EnvVarSource{
+			SecretKeyRef: &corev1.SecretKeySelector{
+				LocalObjectReference: corev1.LocalObjectReference{
+					Name: secretName,
+				},
+				Key:      envVarName,
+				Optional: nil,
 			},
-			Key:      envVarName,
-			Optional: nil,
-		},
-	}
-	acceptorsEnvVar := &corev1.EnvVar{
-		Name:      envVarName,
-		Value:     "",
-		ValueFrom: acceptorsEnvVarSource,
-	}
-	if amqAcceptorsEnvVar := environments.Retrieve(currentStatefulSet.Spec.Template.Spec.Containers, envVarName); nil == amqAcceptorsEnvVar {
-		environments.Create(currentStatefulSet.Spec.Template.Spec.Containers, acceptorsEnvVar)
+		}
+
+		acceptorsEnvVar := &corev1.EnvVar {
+			Name:      envVarName,
+			Value:     "",
+			ValueFrom: acceptorsEnvVarSource,
+		}
+		if amqAcceptorsEnvVar := environments.Retrieve(currentStatefulSet.Spec.Template.Spec.Containers, envVarName); nil == amqAcceptorsEnvVar {
+			environments.Create(currentStatefulSet.Spec.Template.Spec.Containers, acceptorsEnvVar)
+		}
 	}
 
 	return retVal
@@ -888,6 +912,7 @@ func (reconciler *ActiveMQArtemisReconciler) processUpgrade(customResource *brok
 
 	deployed, err := getDeployedResources(customResource, client)
 	if err != nil {
+		reqLogger.Error(err, "error getting deployed resources", "returned", stepsComplete)
 		return stepsComplete
 	}
 
@@ -930,9 +955,10 @@ func (reconciler *ActiveMQArtemisReconciler) processUpgrade(customResource *brok
 			default:
 				if err := resources.Retrieve(namespacedName, client, requested); err != nil {
 					if errors.IsNotFound(err) {
-						resources.Create(customResource, namespacedName, client, scheme, requested)
+						if createError = resources.Create(customResource, namespacedName, client, scheme, requested); createError != nil {
+							reqLogger.Error(createError, "Failed to create resource", "kind", kind, "requested", requested)
+						}
 					}
-
 				}
 			}
 		}

--- a/pkg/controller/broker/v2alpha2/activemqartemis/activemqartemis_reconciler.go
+++ b/pkg/controller/broker/v2alpha2/activemqartemis/activemqartemis_reconciler.go
@@ -267,7 +267,7 @@ func sourceEnvVarFromSecret(customResource *brokerv2alpha2.ActiveMQArtemis, curr
 		for k := range *envVars {
 			elem, ok := nettySecret.Data[k]
 			if 0 != strings.Compare(string(elem), (*envVars)[k]) || !ok {
-				log.Info("Secret exists but not equals, or not ok", "elem", string(elem), "entry", (*envVars)[k], "ok?", ok)
+				log.Info("Secret exists but not equals, or not ok", "ok?", ok)
 				nettySecret.Data[k] = []byte((*envVars)[k])
 				needUpdate = true
 			}
@@ -285,7 +285,7 @@ func sourceEnvVarFromSecret(customResource *brokerv2alpha2.ActiveMQArtemis, curr
 		}
 	}
 
-	log.Info("Pupulating env vars", "envVars", *envVars)
+	log.Info("Populating env vars")
 
 	for envVarName := range *envVars {
 


### PR DESCRIPTION
The issue is caused by multiple updates of one secret.
The first creates the secret then the second resulted
in an update of the statefulset that causes the already
started deployment to restart. The idea is to group
secret creation in one go so it won't trigger the
update of statefulset.